### PR TITLE
chore: move chai-as-promised to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -277,6 +277,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
       "integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
+      "dev": true,
       "requires": {
         "check-error": "1.0.2"
       }
@@ -297,7 +298,8 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "child-process-promise": {
       "version": "2.2.1",
@@ -2495,14 +2497,6 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2528,6 +2522,14 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/interledger/ilp-plugin-virtual#readme",
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
     "co-mocha": "^1.1.3",
     "cz-conventional-changelog": "^1.1.6",
     "eslint": "^4.2.0",
@@ -52,7 +53,6 @@
   "dependencies": {
     "base64url": "^2.0.0",
     "bignumber.js": "^2.3.0",
-    "chai-as-promised": "^6.0.0",
     "debug": "^2.2.0",
     "deep-equal": "^1.0.1",
     "eventemitter2": "^2.2.0",


### PR DESCRIPTION
This avoids npm warning that chai isn't installed