### PR TITLE
feat: allow relying on plugin.addSocket

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -104,10 +104,6 @@ module.exports = class PluginPaymentChannel extends EventEmitter2 {
       this._listener = null
     }
 
-    if (!opts.server && !opts.listener) {
-      throw new Error('plugin must be configured either as a client (in which case you need to provide a \'server\' in the config) or as a server (in which case you need to provide a \'listener\' config)')
-    }
-
     // register RPC methods
     this._rpc = new BtpRpc({
       plugin: this,


### PR DESCRIPTION
Replaces https://github.com/interledgerjs/ilp-plugin-payment-channel-framework/pull/30

As discussed in https://github.com/interledgerjs/ilp-plugin-payment-channel-framework/issues/29#issuecomment-331975300 the preferred way to instantiate a plugin for an incoming connection will be using addSocket instead of via the config.

The config will only be used for the one-peer-per-port situation (including of course then the one-peer-one-port situation), and for instantiating a BTP plugin the plays the client role.

If you want to use one WebSocket server for multiple peers, you need to instantiate their plugins with neither `server` nor `listener` in the config, and then call `plugin.addSocket` from the outside to give its socket.