### PR TITLE
authCheck function

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -115,9 +115,12 @@ module.exports = class PluginPaymentChannel extends EventEmitter2 {
         [Btp.TYPE_REJECT]: this._handleRejectIncomingTransfer.bind(this),
         [Btp.TYPE_MESSAGE]: this._handleRequest.bind(this)
       },
-      // the token with which incoming sockets are authenticated. If there
-      // is no listener, then this argument is unnecessary.
-      incomingAuthToken: opts.incomingSecret
+      // checks the token with which incoming sockets are authenticated. If there
+      // is no listener, and addSocket will not be called for incoming
+      // BTP connections, then this argument is unnecessary.
+      authCheck: (opts.authCheck || function (username, token) {
+        return (username === '' && token === opts.incomingSecret)
+      })
     })
 
     if (!opts.server && !(opts.prefix && opts.info)) {

--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -31,7 +31,7 @@ function jsErrorToBtpError (e) {
 }
 
 module.exports = class BtpRpc extends EventEmitter {
-  constructor ({ client, plugin, handlers, incomingAuthToken, debug }) {
+  constructor ({ client, plugin, handlers, authCheck, debug }) {
     assert(typeof handlers[btpPacket.TYPE_PREPARE] === 'function', 'Prepare handler missing')
     assert(typeof handlers[btpPacket.TYPE_FULFILL] === 'function', 'Fulfill handler missing')
     assert(typeof handlers[btpPacket.TYPE_REJECT] === 'function', 'Reject handler missing')
@@ -44,7 +44,7 @@ module.exports = class BtpRpc extends EventEmitter {
     this._handlers = handlers
     this._client = client
     this._plugin = plugin
-    this._incomingAuthToken = incomingAuthToken
+    this._authCheck = authCheck
     this.debug = debug
   }
 
@@ -108,10 +108,10 @@ module.exports = class BtpRpc extends EventEmitter {
       return new Promise((resolve, reject) => {
         let timer = setTimeout(() => {
           const socketData = this._sockets[newSocketIndex]
-          if (socketData && !socketData.authenticated) { 
+          if (socketData && !socketData.authenticated) {
             this.debug('timing out socket #' + newSocketIndex)
             this._deleteSocket(newSocketIndex)
-            reject()
+            reject(new Error('client did not send correct auth message in time'))
           }
         }, DEFAULT_AUTH_TIMEOUT)
         this.on('authenticated', () => {
@@ -238,9 +238,8 @@ module.exports = class BtpRpc extends EventEmitter {
 
     const isValidAndAuthorized =
       authUsername.contentType === btpPacket.MIME_TEXT_PLAIN_UTF8 &&
-      authUsername.data.toString() === '' &&
       authToken.contentType === btpPacket.MIME_TEXT_PLAIN_UTF8 &&
-      authToken.data.toString() === this._incomingAuthToken
+      this._authCheck(authUsername.data.toString(), authToken.data.toString())
 
     if (!isValidAndAuthorized) {
       this.debug(`responding to invalid auth token: ${authToken}`)

--- a/test/infoSpec.js
+++ b/test/infoSpec.js
@@ -133,7 +133,7 @@ describe('Info', () => {
   describe('authentication', () => {
     beforeEach(async function () {
       this.newSocket = new MockSocket()
-      await this.plugin.addSocket(this.newSocket)
+      this.plugin.addSocket(this.newSocket)
     })
 
     afterEach(async function () {


### PR DESCRIPTION
When calling addSocket as a client, the Promise returned by that
call doesn't resolve until auth has finished.
When calling addSocket as a server, the same should be true.

Also, it would be nice to support `auth_username` values other than `''`.
And lastly, it would be nice to support having different tokens for different peers (not just one `incomingSecret` value which all your peers know).

I'll see if I can come up with a way to fix those three problems all at once.