### PR TITLE
fix: don't crash when additional_info is undefined

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -555,7 +555,7 @@ module.exports = class PluginPaymentChannel extends EventEmitter2 {
       triggeredBy: reason.triggered_by,
       forwardedBy,
       triggeredAt: reason.triggered_at,
-      data: JSON.stringify(reason.additional_info)
+      data: JSON.stringify(reason.additional_info) || ''
     })
 
     this._safeEmit('incoming_reject', transferInfo.transfer, reason)

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -400,12 +400,14 @@ describe('Conditional Transfers', () => {
         return btpPacket.serializeResponse(requestId, [])
       })
 
+      const triggeredAt = new Date()
+
       const ilpError = {
         code: 'F00',
         name: 'Bad Request',
         triggeredBy: 'test.your.friendly.peer',
         forwardedBy: ['test.some.connector', 'test.some.other.connector'],
-        triggeredAt: new Date(),
+        triggeredAt,
         data: JSON.stringify({ extra: 'data' })
       }
       const reason = {
@@ -413,7 +415,7 @@ describe('Conditional Transfers', () => {
         name: 'Bad Request',
         triggered_by: 'test.your.friendly.peer',
         forwarded_by: 'test.some.other.connector',
-        triggered_at: new Date(),
+        triggered_at: triggeredAt,
         additional_info: { extra: 'data' }
       }
 


### PR DESCRIPTION
`JSON.stringify(undefined) === undefined` which triggers a crash in `ilp-packet`.